### PR TITLE
Fixed travis' node versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
     - 0.8
-    - 0.10
+    - 0.9
 before_install:
     git submodule update --init


### PR DESCRIPTION
Travis handle node v0.6, v0.8, and v0.9. 
v0.10 was fallbacking on v0.8.
