### PR TITLE
fix canonicalisation of paths

### DIFF
--- a/src/canonicalise.coffee
+++ b/src/canonicalise.coffee
@@ -1,3 +1,5 @@
 path = require 'path'
 
-module.exports = (root, file) -> "/#{path.relative root, file}".replace /\\/g, '/'
+module.exports = (root, file) ->
+    file = path.resolve(root, file) # in case if file is a relative path
+    "/#{path.relative root, file}".replace /\\/g, '/'


### PR DESCRIPTION
Before that when I were doing `cjsify -r src main.coffee -o build/out.js`, everything would be normal except for the root require, which would look like `require('/../main.coffee')`. This change fixes the problem.
