### PR TITLE
Don't die on import of unimplemented core modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 commonjs-everywhere-*.tgz
 test/fixtures/*
+node_modules

--- a/lib/relative-resolve.js
+++ b/lib/relative-resolve.js
@@ -25,8 +25,10 @@ void function () {
       if ({}.hasOwnProperty.call(aliases, givenPath))
         return;
       corePath = CORE_MODULES[givenPath];
-      if (!fs.existsSync(corePath))
-        throw new Error('Core module "' + givenPath + '" has not yet been ported to the browser');
+      if (!fs.existsSync(corePath)) {
+        console.log('Core module "' + givenPath + '" has not yet been ported to the browser');
+        return;
+      }
       givenPath = corePath;
     }
     try {

--- a/src/relative-resolve.coffee
+++ b/src/relative-resolve.coffee
@@ -13,7 +13,8 @@ resolvePath = ({extensions, aliases, root, cwd, path: givenPath}) ->
     return if {}.hasOwnProperty.call aliases, givenPath
     corePath = CORE_MODULES[givenPath]
     unless fs.existsSync corePath
-      throw new Error "Core module \"#{givenPath}\" has not yet been ported to the browser"
+      console.log "Core module \"#{givenPath}\" has not yet been ported to the browser"
+      return
     givenPath = corePath
   # try regular CommonJS requires
   try resolve givenPath, {extensions, basedir: cwd or root}


### PR DESCRIPTION
Warn, but continue.  In many cases, there may be a check to see if the
user is in the browser and not use, say, fs if they are.
