### PR TITLE
makefile: add missing .PHONY declarations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ lib/%.js: src/%.coffee
 	@dirname "$@" | xargs mkdir -p
 	$(COFFEE) <"$<" >"$@"
 
-.PHONY: release test loc clean
+.PHONY: all build release release-patch release-minor release-major test loc clean
 
 VERSION = $(shell node -p 'require("./package.json").version')
 release-patch: NEXT_VERSION = $(shell node -p 'require("semver").inc("$(VERSION)", "patch")')


### PR DESCRIPTION
Perhaps you're relying on files with these names never existing. `all` and `build` should be declared phony, too, I imagine.
