### PR TITLE
makefile: replace unnecessary use of xargs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ all: build test
 build: $(LIB)
 
 lib/%.js: src/%.coffee
-	@dirname "$@" | xargs mkdir -p
+	@mkdir -p "$(@D)"
 	$(COFFEE) <"$<" >"$@"
 
 .PHONY: all build release release-patch release-minor release-major test loc clean


### PR DESCRIPTION
Questions:
- Is there any value in quoting filenames in this context? After reading [GNU Make meets file names with spaces in them](http://www.cmcrossroads.com/article/gnu-make-meets-file-names-spaces-them) I'm don't think there's much hope of correctly handling filenames containing spaces.
- Is there a reason to favour this two-step process over `$(COFFEE) -co $(@D) $<`? The latter would obviate the need for `mkdir` on our part.
