### PR TITLE
makefile: prevent hypothetical double expansion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ default: build
 
 CHANGELOG=CHANGELOG
 
-SRC = $(shell find src -name "*.coffee" -type f | sort)
+SRC = $(shell find src -name '*.coffee' -type f | sort)
 LIB = $(SRC:src/%.coffee=lib/%.js)
 
 COFFEE=node_modules/.bin/coffee --js
@@ -13,8 +13,8 @@ all: build test
 build: $(LIB)
 
 lib/%.js: src/%.coffee
-	@mkdir -p "$(@D)"
-	$(COFFEE) <"$<" >"$@"
+	@mkdir -p '$(@D)'
+	$(COFFEE) <'$<' >'$@'
 
 .PHONY: default all build release-patch release-minor release-major test loc clean
 
@@ -24,16 +24,16 @@ release-minor: NEXT_VERSION = $(shell $(SEMVER) -i minor $(VERSION))
 release-major: NEXT_VERSION = $(shell $(SEMVER) -i major $(VERSION))
 
 release-patch release-minor release-major: build test
-	@printf "Current version is $(VERSION). This will publish version $(NEXT_VERSION). Press [enter] to continue." >&2
+	@printf 'Current version is $(VERSION). This will publish version $(NEXT_VERSION). Press [enter] to continue.' >&2
 	@read
-	./changelog.sh "v$(NEXT_VERSION)" >"$(CHANGELOG)"
+	./changelog.sh 'v$(NEXT_VERSION)' >'$(CHANGELOG)'
 	node -e '\
 		var j = require("./package.json");\
 		j.version = "$(NEXT_VERSION)";\
 		var s = JSON.stringify(j, null, 2) + "\n";\
 		require("fs").writeFileSync("./package.json", s);'
-	git commit package.json "$(CHANGELOG)" -m 'Version $(NEXT_VERSION)'
-	git tag -a "v$(NEXT_VERSION)" -m "Version $(NEXT_VERSION)"
+	git commit package.json '$(CHANGELOG)' -m 'Version $(NEXT_VERSION)'
+	git tag -a 'v$(NEXT_VERSION)' -m 'Version $(NEXT_VERSION)'
 	git push --tags origin HEAD:master
 	npm publish
 


### PR DESCRIPTION
Commit message:

> Given the following makefile:
> 
> ``` make
> X = $(shell echo '$$HOME')
> 
> example:
>     @echo 'single-quoted: $(X)'
>     @echo "double-quoted: $(X)"
> ```
> 
> Running `make` will output something similar to the following:
> 
> ```
> single-quoted: $HOME
> double-quoted: /Users/dc
> ```
> 
> Though double expansion will almost certainly never occur in practice, there's no downside to correctness in this case.

This project provides an excellent example of a makefile for a Node package. This is the reason I consider such trivial improvements worthwhile. :)
