### PR TITLE
makefile: integrate xyz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
   - "0.8"
-  - "0.9"
   - "0.10"
 before_install:
   git submodule update --init

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,11 @@
 default: build
 
-CHANGELOG=CHANGELOG
-
 SRC = $(shell find src -name '*.coffee' -type f | sort)
 LIB = $(SRC:src/%.coffee=lib/%.js)
 
 COFFEE=node_modules/.bin/coffee --js
 MOCHA=node_modules/.bin/mocha --compilers coffee:coffee-script-redux/register -r test-setup.coffee -u tdd
-SEMVER=node_modules/.bin/semver
+XYZ=node_modules/.bin/xyz --repo git@github.com:michaelficarra/commonjs-everywhere.git --script changelog.sh
 
 all: build test
 build: $(LIB)
@@ -18,24 +16,8 @@ lib/%.js: src/%.coffee
 
 .PHONY: default all build release-patch release-minor release-major test loc clean
 
-VERSION = $(shell node -p 'require("./package.json").version')
-release-patch: NEXT_VERSION = $(shell $(SEMVER) -i patch $(VERSION))
-release-minor: NEXT_VERSION = $(shell $(SEMVER) -i minor $(VERSION))
-release-major: NEXT_VERSION = $(shell $(SEMVER) -i major $(VERSION))
-
-release-patch release-minor release-major: build test
-	@printf 'Current version is $(VERSION). This will publish version $(NEXT_VERSION). Press [enter] to continue.' >&2
-	@read
-	./changelog.sh 'v$(NEXT_VERSION)' >'$(CHANGELOG)'
-	node -e '\
-		var j = require("./package.json");\
-		j.version = "$(NEXT_VERSION)";\
-		var s = JSON.stringify(j, null, 2) + "\n";\
-		require("fs").writeFileSync("./package.json", s);'
-	git commit package.json '$(CHANGELOG)' -m 'Version $(NEXT_VERSION)'
-	git tag -a 'v$(NEXT_VERSION)' -m 'Version $(NEXT_VERSION)'
-	git push origin refs/heads/master 'refs/tags/v$(NEXT_VERSION)'
-	npm publish
+release-major release-minor release-patch: build test
+	@$(XYZ) --increment $(@:release-%=%)
 
 test:
 	$(MOCHA) -R dot test/*.coffee

--- a/changelog.sh
+++ b/changelog.sh
@@ -1,16 +1,24 @@
-if [ $# -gt 0 ]; then next_version=$1; else next_version=master; fi
-initial_commit=$(git log --pretty=%H | tail -1)
+#!/usr/bin/env bash
+set -e
 
-printf "$next_version"
-date '+ (%Y-%m-%d)'
+log() {
+  git --no-pager log --abbrev=8 --date=short "$@"
+}
 
+logcommits() {
+  log --pretty='- %h: %s' "$@"
+}
+
+initial_commit=$(git rev-list --max-parents=0 HEAD)
+
+>CHANGELOG
 tags=($(echo $initial_commit; git tag; echo master))
 for ((i = ${#tags[@]}-1; i > 0; i--)); do
-  if [ "${tags[i]}" '!=' master ]; then
-    printf "${tags[i]}"
-    git --no-pager log -1 --date=short --pretty=' (%ad)' "${tags[i]}"
-  fi
-  git --no-pager log --date=short --pretty='- %h: %s' "${tags[i-1]}..${tags[i]}"
-  if [ $i -gt 1 ]; then echo; fi
+  v=\\n${tags[i]}
+  v=${v/\\nmaster/v$VERSION}
+  printf "$v ($(log -1 --pretty=%ad ${tags[i]}))\n" >>CHANGELOG
+  logcommits ${tags[i-1]}..${tags[i]} >>CHANGELOG
 done
-git --no-pager log -1 --date=short --pretty='- %h: %s' $initial_commit
+logcommits $initial_commit >>CHANGELOG
+
+git add CHANGELOG

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "coffee-script-redux": "2.0.0-beta8",
     "mocha": "~1.14.0",
     "scopedfs": "~0.1.0",
-    "semver": "~2.2.1"
+    "xyz": "0.5.x"
   },
   "scripts": {
     "test": "make test"


### PR DESCRIPTION
This cannot be merged as is. The problem is the automatic CHANGELOG generation, which requires knowledge of the new version number. Perhaps [xyz](https://github.com/davidchambers/xyz) should accept a path to an arbitrary script to be run immediately after the confirmation prompt. This script could be passed the new version number as $1.
