### PR TITLE
Full zlib compatibility with node

### DIFF
--- a/lib/core-modules.js
+++ b/lib/core-modules.js
@@ -13,7 +13,7 @@ void function () {
     punycode: resolve('punycode'),
     querystring: resolve('querystring'),
     vm: resolve('vm-browserify'),
-    zlib: resolve('zlib-browserify')
+    zlib: resolve('browserify-zlib')
   };
   NODE_CORE_MODULES = [
     '_stream_duplex',

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "punycode": "*",
     "querystring": "*",
     "vm-browserify": "*",
-    "zlib-browserify": "*"
+    "browserify-zlib": "*"
   },
   "devDependencies": {
     "coffee-script-redux": "2.0.0-beta8",

--- a/src/core-modules.coffee
+++ b/src/core-modules.coffee
@@ -12,7 +12,7 @@ CORE_MODULES =
   punycode: resolve 'punycode'
   querystring: resolve 'querystring'
   vm: resolve 'vm-browserify'
-  zlib: resolve 'zlib-browserify'
+  zlib: resolve 'browserify-zlib'
 
 NODE_CORE_MODULES = [
   '_stream_duplex'


### PR DESCRIPTION
Browserify recently [switched](https://github.com/substack/node-browserify/pull/721) to a new [zlib module](https://github.com/devongovett/browserify-zlib) that I wrote, with full Node API and binary output compatibility.     I thought I'd help out other browser bundlers using the old zlib module as well. :wink:
