### PR TITLE
support for using a custom modules dir for third party modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ CommonJS (node module) browser bundler with source maps from the minified JS bun
       -v, --verbose             verbose output sent to stderr
       -w, --watch               watch input files/dependencies for changes and rebuild bundle
       -x, --export NAME         export the given entry module as NAME
+      -d, --modules-dir DIR     use this relative dir for looking up third party modules e.g. replace node_modules
       --deps                    do not bundle; just list the files that would be bundled
       --help                    display this help message and exit
       --ignore-missing          continue without error when dependency resolution fails
@@ -69,6 +70,7 @@ Bundles the given file and its dependencies; returns a Spidermonkey AST represen
     * `node`: a falsey value causes the bundling phase to omit the `process` stub that emulates a node environment
     * `verbose`: log additional operational information to stderr
     * `ignoreMissing`: continue without error when dependency resolution fails
+    * `modulesDir`: use this relative dir for looking up third party modules
 
 ## Examples
 

--- a/lib/command.js
+++ b/lib/command.js
@@ -38,7 +38,8 @@ void function () {
         'export',
         'output',
         'root',
-        'source-map'
+        'source-map',
+        'modules-dir'
       ], i$1 = 0, length$1 = cache$1.length; i$1 < length$1; ++i$1) {
     opt = cache$1[i$1];
     knownOpts[opt] = String;
@@ -62,7 +63,8 @@ void function () {
     s: '--source-map',
     v: '--verbose',
     w: '--watch',
-    x: '--export'
+    x: '--export',
+    d: '--modules-dir'
   };
   options = nopt(knownOpts, optAliases, process.argv, 2);
   positionalArgs = options.argv.remain;
@@ -87,10 +89,11 @@ void function () {
   options.sourceMap = options['source-map'];
   options.inlineSources = options['inline-sources'];
   options.inlineSourceMap = options['inline-source-map'];
+  options.modulesDir = options['modules-dir'];
   if (options.help) {
     $0 = process.argv[0] === 'node' ? process.argv[1] : process.argv[0];
     $0 = path.basename($0);
-    console.log('\n  Usage: ' + $0 + ' OPT* path/to/entry-file.ext OPT*\n\n  -a, --alias ALIAS:TO      replace requires of file identified by ALIAS with TO\n  -h, --handler EXT:MODULE  handle files with extension EXT with module MODULE\n  -m, --minify              minify output\n  -o, --output FILE         output to FILE instead of stdout\n  -r, --root DIR            unqualified requires are relative to DIR; default: cwd\n  -s, --source-map FILE     output a source map to FILE\n  -v, --verbose             verbose output sent to stderr\n  -w, --watch               watch input files/dependencies for changes and rebuild bundle\n  -x, --export NAME         export the given entry module as NAME\n  --deps                    do not bundle; just list the files that would be bundled\n  --help                    display this help message and exit\n  --ignore-missing          continue without error when dependency resolution fails\n  --inline-source-map       include the source map as a data URI in the generated bundle\n  --inline-sources          include source content in generated source maps; default: on\n  --node                    include process object; emulate node environment; default: on\n  --version                 display the version number and exit\n');
+    console.log('\n  Usage: ' + $0 + ' OPT* path/to/entry-file.ext OPT*\n\n  -a, --alias ALIAS:TO      replace requires of file identified by ALIAS with TO\n  -h, --handler EXT:MODULE  handle files with extension EXT with module MODULE\n  -m, --minify              minify output\n  -o, --output FILE         output to FILE instead of stdout\n  -r, --root DIR            unqualified requires are relative to DIR; default: cwd\n  -s, --source-map FILE     output a source map to FILE\n  -v, --verbose             verbose output sent to stderr\n  -w, --watch               watch input files/dependencies for changes and rebuild bundle\n  -x, --export NAME         export the given entry module as NAME\n  -d, --modules-dir DIR     use this relative dir for looking up modules e.g. replace node_modules\n  --deps                    do not bundle; just list the files that would be bundled\n  --help                    display this help message and exit\n  --ignore-missing          continue without error when dependency resolution fails\n  --inline-source-map       include the source map as a data URI in the generated bundle\n  --inline-sources          include source content in generated source maps; default: on\n  --node                    include process object; emulate node environment; default: on\n  --version                 display the version number and exit\n');
     process.exit(0);
   }
   if (options.version) {

--- a/lib/relative-resolve.js
+++ b/lib/relative-resolve.js
@@ -8,7 +8,7 @@ void function () {
   isCore = require('./is-core');
   canonicalise = require('./canonicalise');
   resolvePath = function (param$) {
-    var aliases, cache$, corePath, cwd, e, extensions, root;
+    var aliases, cache$, corePath, cwd, e, extensions, modulesDir, root;
     var givenPath;
     {
       cache$ = param$;
@@ -17,6 +17,7 @@ void function () {
       root = cache$.root;
       cwd = cache$.cwd;
       givenPath = cache$.path;
+      modulesDir = cache$.modulesDir;
     }
     if (null != aliases)
       aliases;
@@ -33,7 +34,8 @@ void function () {
     try {
       return resolve(givenPath, {
         extensions: extensions,
-        basedir: cwd || root
+        basedir: cwd || root,
+        moduleDirectory: modulesDir || 'node_modules'
       });
     } catch (e$) {
       e = e$;
@@ -45,7 +47,7 @@ void function () {
       }
     }
   };
-  module.exports = function (param$) {
+  module.exports = function (param$, modulesDir) {
     var alias, aliases, cache$, canonicalName, cwd, extensions, givenPath, resolved, root;
     {
       cache$ = param$;
@@ -64,7 +66,8 @@ void function () {
       aliases: aliases,
       root: root,
       cwd: cwd,
-      path: givenPath
+      path: givenPath,
+      modulesDir: modulesDir
     });
     canonicalName = isCore(givenPath) ? givenPath : canonicalise(root, resolved);
     while ({}.hasOwnProperty.call(aliases, '/' + canonicalName) || {}.hasOwnProperty.call(aliases, canonicalName)) {
@@ -73,7 +76,8 @@ void function () {
         extensions: extensions,
         aliases: aliases,
         root: root,
-        path: alias
+        path: alias,
+        modulesDir: modulesDir
       }) : void 0;
       if (!resolved)
         break;

--- a/lib/relative-resolve.js
+++ b/lib/relative-resolve.js
@@ -23,6 +23,7 @@ void function () {
       aliases;
     else
       aliases = {};
+    console.log('resolvePath: ' + modulesDir);
     if (isCore(givenPath)) {
       if ({}.hasOwnProperty.call(aliases, givenPath))
         return;
@@ -47,8 +48,8 @@ void function () {
       }
     }
   };
-  module.exports = function (param$, modulesDir) {
-    var alias, aliases, cache$, canonicalName, cwd, extensions, givenPath, resolved, root;
+  module.exports = function (param$) {
+    var alias, aliases, cache$, canonicalName, cwd, extensions, givenPath, modulesDir, resolved, root;
     {
       cache$ = param$;
       extensions = cache$.extensions;
@@ -56,11 +57,13 @@ void function () {
       root = cache$.root;
       cwd = cache$.cwd;
       givenPath = cache$.path;
+      modulesDir = cache$.modulesDir;
     }
     if (null != aliases)
       aliases;
     else
       aliases = {};
+    console.log('relativeResolve: ' + modulesDir);
     resolved = resolvePath({
       extensions: extensions,
       aliases: aliases,

--- a/lib/relative-resolve.js
+++ b/lib/relative-resolve.js
@@ -23,7 +23,6 @@ void function () {
       aliases;
     else
       aliases = {};
-    console.log('resolvePath: ' + modulesDir);
     if (isCore(givenPath)) {
       if ({}.hasOwnProperty.call(aliases, givenPath))
         return;
@@ -63,7 +62,6 @@ void function () {
       aliases;
     else
       aliases = {};
-    console.log('relativeResolve: ' + modulesDir);
     resolved = resolvePath({
       extensions: extensions,
       aliases: aliases,

--- a/lib/traverse-dependencies.js
+++ b/lib/traverse-dependencies.js
@@ -15,12 +15,13 @@ void function () {
     throw 'illegal require: ' + msg + '\n  `' + require('escodegen').generate(node) + '`\n  in ' + filename + '';
   };
   module.exports = function (entryPoint, root, options) {
-    var aliases, ast, astOrJs, cache$, cache$1, canonicalName, digest, e, ext, extensions, extname, fileContents, filename, handler, handlers, processed, worklist;
+    var aliases, ast, astOrJs, cache$, cache$1, canonicalName, digest, e, ext, extensions, extname, fileContents, filename, handler, handlers, modulesDir, processed, worklist;
     if (null == root)
       root = process.cwd();
     if (null == options)
       options = {};
     aliases = null != options.aliases ? options.aliases : {};
+    modulesDir = null != options.modulesDir ? options.modulesDir : 'node_modules';
     handlers = {
       '.coffee': function (coffee, canonicalName) {
         return CoffeeScript.compile(CoffeeScript.parse(coffee, { raw: true }), { bare: true });
@@ -50,7 +51,8 @@ void function () {
         extensions: extensions,
         aliases: aliases,
         root: root,
-        path: entryPoint
+        path: entryPoint,
+        modulesDir: modulesDir
       })];
     processed = {};
     while (worklist.length) {

--- a/lib/traverse-dependencies.js
+++ b/lib/traverse-dependencies.js
@@ -112,7 +112,8 @@ void function () {
               aliases: aliases,
               root: root,
               cwd: cwd,
-              path: node['arguments'][0].value
+              path: node['arguments'][0].value,
+              modulesDir: modulesDir
             });
             worklist.push(resolved);
           } catch (e$1) {

--- a/src/command.coffee
+++ b/src/command.coffee
@@ -24,7 +24,7 @@ knownOpts[opt] = Boolean for opt in [
   'inline-sources', 'minify', 'node', 'verbose', 'watch'
 ]
 # parameters
-knownOpts[opt] = String for opt in ['export', 'output', 'root', 'source-map']
+knownOpts[opt] = String for opt in ['export', 'output', 'root', 'source-map', 'modules-dir']
 # list parameters
 knownOpts[opt] = [String, Array] for opt in ['alias', 'handler']
 
@@ -38,6 +38,7 @@ optAliases =
   v: '--verbose'
   w: '--watch'
   x: '--export'
+  d: '--modules-dir'
 
 options = nopt knownOpts, optAliases, process.argv, 2
 positionalArgs = options.argv.remain
@@ -53,6 +54,7 @@ options.ignoreMissing = options['ignore-missing']
 options.sourceMap = options['source-map']
 options.inlineSources = options['inline-sources']
 options.inlineSourceMap = options['inline-source-map']
+options.modulesDir = options['modules-dir']
 
 if options.help
   $0 = if process.argv[0] is 'node' then process.argv[1] else process.argv[0]
@@ -69,6 +71,7 @@ if options.help
   -v, --verbose             verbose output sent to stderr
   -w, --watch               watch input files/dependencies for changes and rebuild bundle
   -x, --export NAME         export the given entry module as NAME
+  -d, --modules-dir DIR     use this relative dir for looking up modules e.g. replace node_modules
   --deps                    do not bundle; just list the files that would be bundled
   --help                    display this help message and exit
   --ignore-missing          continue without error when dependency resolution fails

--- a/src/relative-resolve.coffee
+++ b/src/relative-resolve.coffee
@@ -9,7 +9,6 @@ canonicalise = require './canonicalise'
 
 resolvePath = ({extensions, aliases, root, cwd, path: givenPath, modulesDir }) ->
   aliases ?= {}
-
   if isCore givenPath
     return if {}.hasOwnProperty.call aliases, givenPath
     corePath = CORE_MODULES[givenPath]

--- a/src/relative-resolve.coffee
+++ b/src/relative-resolve.coffee
@@ -9,6 +9,8 @@ canonicalise = require './canonicalise'
 
 resolvePath = ({extensions, aliases, root, cwd, path: givenPath, modulesDir }) ->
   aliases ?= {}
+  console.log( 'resolvePath: ' + modulesDir)
+
   if isCore givenPath
     return if {}.hasOwnProperty.call aliases, givenPath
     corePath = CORE_MODULES[givenPath]
@@ -22,8 +24,9 @@ resolvePath = ({extensions, aliases, root, cwd, path: givenPath, modulesDir }) -
     try resolve (path.join root, givenPath), {extensions}
     catch e then throw new Error "Cannot find module \"#{givenPath}\" in \"#{root}\""
 
-module.exports = ({extensions, aliases, root, cwd, path: givenPath}, modulesDir ) ->
+module.exports = ({extensions, aliases, root, cwd, path: givenPath, modulesDir } ) ->
   aliases ?= {}
+  console.log( 'relativeResolve: ' + modulesDir)
   resolved = resolvePath {extensions, aliases, root, cwd, path: givenPath, modulesDir }
   canonicalName = if isCore givenPath then givenPath else canonicalise root, resolved
   while ({}.hasOwnProperty.call aliases, "/#{canonicalName}") or

--- a/src/relative-resolve.coffee
+++ b/src/relative-resolve.coffee
@@ -9,7 +9,6 @@ canonicalise = require './canonicalise'
 
 resolvePath = ({extensions, aliases, root, cwd, path: givenPath, modulesDir }) ->
   aliases ?= {}
-  console.log( 'resolvePath: ' + modulesDir)
 
   if isCore givenPath
     return if {}.hasOwnProperty.call aliases, givenPath
@@ -26,7 +25,6 @@ resolvePath = ({extensions, aliases, root, cwd, path: givenPath, modulesDir }) -
 
 module.exports = ({extensions, aliases, root, cwd, path: givenPath, modulesDir } ) ->
   aliases ?= {}
-  console.log( 'relativeResolve: ' + modulesDir)
   resolved = resolvePath {extensions, aliases, root, cwd, path: givenPath, modulesDir }
   canonicalName = if isCore givenPath then givenPath else canonicalise root, resolved
   while ({}.hasOwnProperty.call aliases, "/#{canonicalName}") or

--- a/src/relative-resolve.coffee
+++ b/src/relative-resolve.coffee
@@ -7,7 +7,7 @@ CORE_MODULES = require './core-modules'
 isCore = require './is-core'
 canonicalise = require './canonicalise'
 
-resolvePath = ({extensions, aliases, root, cwd, path: givenPath}) ->
+resolvePath = ({extensions, aliases, root, cwd, path: givenPath, modulesDir }) ->
   aliases ?= {}
   if isCore givenPath
     return if {}.hasOwnProperty.call aliases, givenPath
@@ -16,20 +16,20 @@ resolvePath = ({extensions, aliases, root, cwd, path: givenPath}) ->
       throw new Error "Core module \"#{givenPath}\" has not yet been ported to the browser"
     givenPath = corePath
   # try regular CommonJS requires
-  try resolve givenPath, {extensions, basedir: cwd or root}
+  try resolve givenPath, {extensions, basedir: cwd or root, moduleDirectory : modulesDir or 'node_modules' }
   catch e
     # support non-standard root-relative requires
     try resolve (path.join root, givenPath), {extensions}
     catch e then throw new Error "Cannot find module \"#{givenPath}\" in \"#{root}\""
 
-module.exports = ({extensions, aliases, root, cwd, path: givenPath}) ->
+module.exports = ({extensions, aliases, root, cwd, path: givenPath}, modulesDir ) ->
   aliases ?= {}
-  resolved = resolvePath {extensions, aliases, root, cwd, path: givenPath}
+  resolved = resolvePath {extensions, aliases, root, cwd, path: givenPath, modulesDir }
   canonicalName = if isCore givenPath then givenPath else canonicalise root, resolved
   while ({}.hasOwnProperty.call aliases, "/#{canonicalName}") or
   ({}.hasOwnProperty.call aliases, canonicalName)
     alias = aliases["/#{canonicalName}"] or aliases[canonicalName]
-    resolved = if alias then resolvePath {extensions, aliases, root, path: alias}
+    resolved = if alias then resolvePath {extensions, aliases, root, path: alias, modulesDir }
     break unless resolved # aliased module cannot be resolved
     canonicalName = canonicalise root, resolved
   {filename: resolved, canonicalName}

--- a/src/traverse-dependencies.coffee
+++ b/src/traverse-dependencies.coffee
@@ -21,7 +21,6 @@ badRequireError = (filename, node, msg) ->
 module.exports = (entryPoint, root = process.cwd(), options = {}) ->
   aliases = options.aliases ? {}
   modulesDir = options.modulesDir ? 'node_modules'
-
   handlers =
     '.coffee': (coffee, canonicalName) ->
       CoffeeScript.compile (CoffeeScript.parse coffee, raw: yes), bare: yes

--- a/src/traverse-dependencies.coffee
+++ b/src/traverse-dependencies.coffee
@@ -20,6 +20,7 @@ badRequireError = (filename, node, msg) ->
 
 module.exports = (entryPoint, root = process.cwd(), options = {}) ->
   aliases = options.aliases ? {}
+  modulesDir = options.modulesDir ? 'node_modules'
 
   handlers =
     '.coffee': (coffee, canonicalName) ->
@@ -30,7 +31,7 @@ module.exports = (entryPoint, root = process.cwd(), options = {}) ->
     handlers[ext] = handler
   extensions = ['.js', (ext for own ext of handlers)...]
 
-  worklist = [relativeResolve {extensions, aliases, root, path: entryPoint}]
+  worklist = [relativeResolve {extensions, aliases, root, path: entryPoint, modulesDir }]
   processed = {}
 
   while worklist.length

--- a/src/traverse-dependencies.coffee
+++ b/src/traverse-dependencies.coffee
@@ -88,7 +88,7 @@ module.exports = (entryPoint, root = process.cwd(), options = {}) ->
           console.error "required \"#{node.arguments[0].value}\" from \"#{canonicalName}\""
         # if we are including this file, its requires need to be processed as well
         try
-          resolved = relativeResolve {extensions, aliases, root, cwd, path: node.arguments[0].value}
+          resolved = relativeResolve {extensions, aliases, root, cwd, path: node.arguments[0].value, modulesDir }
           worklist.push resolved
         catch e
           if options.ignoreMissing


### PR DESCRIPTION
I've added support for passing a `root` relative `dir` for looking up third party modules ala `node_modules` style as [explained here](https://github.com/michaelficarra/commonjs-everywhere/issues/106)

Command Line Usage

``` bash
cjsifiy app.js --root js/ --modules-dir components/ 
```

Node Usage

``` js
cjsify ( './app.js', __dirname + '/js', { modulesDir : './components' } );
```

The docs have also been updated.
